### PR TITLE
Fix inline code HTML escaping and test paths

### DIFF
--- a/md_parser.py
+++ b/md_parser.py
@@ -34,8 +34,12 @@ def parse_markdown(lines):
 
     def parse_inline(text):
         text = re.sub(r'\\([*#`\[\]])', r'\1', text)
-        text = re.sub(r'``([^`]+)``', r'<code>\1</code>', text)
-        text = re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+
+        def repl_code(match):
+            return '<code>' + escape_html(match.group(1)) + '</code>'
+
+        text = re.sub(r'``([^`]+)``', repl_code, text)
+        text = re.sub(r'`([^`]+)`', repl_code, text)
         text = re.sub(r'\*\*\*([^*]+)\*\*\*', r'<em><strong>\1</strong></em>', text)
         text = re.sub(r'\*\*([^*]+)\*\*', r'<strong>\1</strong>', text)
         text = re.sub(r'\*([^*]+)\*', r'<em>\1</em>', text)

--- a/parser.py
+++ b/parser.py
@@ -34,8 +34,12 @@ def parse_markdown(lines):
 
     def parse_inline(text):
         text = re.sub(r'\\([*#`\[\]])', r'\1', text)
-        text = re.sub(r'``([^`]+)``', r'<code>\1</code>', text)
-        text = re.sub(r'`([^`]+)`', r'<code>\1</code>', text)
+
+        def repl_code(match):
+            return '<code>' + escape_html(match.group(1)) + '</code>'
+
+        text = re.sub(r'``([^`]+)``', repl_code, text)
+        text = re.sub(r'`([^`]+)`', repl_code, text)
         text = re.sub(r'\*\*\*([^*]+)\*\*\*', r'<em><strong>\1</strong></em>', text)
         text = re.sub(r'\*\*([^*]+)\*\*', r'<strong>\1</strong>', text)
         text = re.sub(r'\*([^*]+)\*', r'<em>\1</em>', text)

--- a/test/inline_code_html.html
+++ b/test/inline_code_html.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Document</title>
+</head>
+<body>
+<p>Here is <code>a &lt; b &amp; c &gt; d</code> example.</p>
+</body>
+</html>

--- a/test/inline_code_html.md
+++ b/test/inline_code_html.md
@@ -1,0 +1,1 @@
+Here is `a < b & c > d` example.

--- a/test/test_md2html.py
+++ b/test/test_md2html.py
@@ -2,22 +2,29 @@ import subprocess
 import os
 import filecmp
 
-# Paths
-script = os.path.join('..', 'md2html.py')
+# Resolve paths relative to this test file so tests can be run from any
+# working directory.
+BASE_DIR = os.path.abspath(os.path.dirname(__file__))
+SCRIPT = os.path.join(BASE_DIR, '..', 'md2html.py')
 test_cases = [
     ('example.md', 'example.html'),
     ('edge_cases.md', 'edge_cases.html'),
+    ('inline_code_html.md', 'inline_code_html.html'),
 ]
 
 def run_converter(input_md, output_html):
-    with open(input_md, 'r', encoding='utf-8') as infile, open(output_html, 'w', encoding='utf-8') as outfile:
-        subprocess.run(['python', script, input_md], stdout=outfile, check=True)
+    input_path = os.path.join(BASE_DIR, input_md)
+    output_path = os.path.join(BASE_DIR, output_html)
+    with open(input_path, 'r', encoding='utf-8') as infile, open(output_path, 'w', encoding='utf-8') as outfile:
+        subprocess.run(['python', SCRIPT, input_path], stdout=outfile, check=True)
 
 def test_conversion():
     for md, expected_html in test_cases:
         output_html = 'output_' + md.replace('.md', '.html')
         run_converter(md, output_html)
-        assert filecmp.cmp(output_html, expected_html, shallow=False), f'{md}: HTML output does not match expected.'
+        output_path = os.path.join(BASE_DIR, output_html)
+        expected_path = os.path.join(BASE_DIR, expected_html)
+        assert filecmp.cmp(output_path, expected_path, shallow=False), f'{md}: HTML output does not match expected.'
         print(f'Test passed: {md} -> {expected_html}')
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- escape HTML in inline code fragments
- fix test helper paths so pytest runs from repo root
- add regression test for inline code containing HTML characters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a65e89a48329bf9e7995b7e58ad7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of inline code to correctly display special HTML characters within code snippets.
- **Tests**
	- Added new test cases to verify proper rendering of inline code containing special characters.
	- Updated test scripts to ensure reliable file path resolution during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->