### PR TITLE
Add placeholder requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ python md2html.py input.md > output.html
 ## Requirements
 
 - Python 3.x
-- No external dependencies (uses only the Python standard library)
+- No external dependencies (uses only the Python standard library). A
+  `requirements.txt` file is included for convenience and is intentionally
+  empty, so `pip install -r requirements.txt` will succeed without
+  installing anything.
 
 ## Example
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No external dependencies required


### PR DESCRIPTION
## Summary
- provide an empty `requirements.txt` so `pip install -r requirements.txt` works
- document the empty requirements in README

## Testing
- `pip install --no-index -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b62abc68c8329a6050d640bde5b07

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify dependency requirements and the inclusion of an empty requirements file.

* **Chores**
  * Added an empty requirements file to improve compatibility with standard installation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->